### PR TITLE
Fix password hashing

### DIFF
--- a/yb_accounts/models.py
+++ b/yb_accounts/models.py
@@ -9,14 +9,14 @@ class MyAccountManager(BaseUserManager):
         if not email:
             raise ValueError("Users must have an email address")
         if not username:
-            raise ValueError("Users ust have a username")
+            raise ValueError("Users must have a username")
 
         user = self.model(
             email=self.normalize_email(email),
             username=username,
         )
 
-        user.setPassword(password)
+        user.set_password(password)
         user.save(using=self._db)
         return user
 

--- a/yb_accounts/tests.py
+++ b/yb_accounts/tests.py
@@ -1,3 +1,14 @@
 from django.test import TestCase
+from .models import Account
 
-# Create your tests here.
+
+class AccountManagerTests(TestCase):
+    def test_create_user_sets_password(self):
+        """Account.objects.create_user should hash the provided password."""
+        user = Account.objects.create_user(
+            email="user@example.com",
+            username="testuser",
+            password="testpass",
+        )
+
+        self.assertTrue(user.check_password("testpass"))


### PR DESCRIPTION
## Summary
- set password with `set_password`
- fix typo in error message
- add regression test checking password hashing

## Testing
- `python manage.py test yb_accounts.tests.AccountManagerTests.test_create_user_sets_password` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684854951fb08324a2b3ba0d83198d3f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected a typo in an error message and fixed password handling to ensure proper password setting for user accounts.

- **Tests**
  - Added a test to verify that user passwords are correctly hashed when creating a new account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->